### PR TITLE
Refactor layout and add LinkedIn link

### DIFF
--- a/certifications.html
+++ b/certifications.html
@@ -10,12 +10,15 @@
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="fond.css">
 </head>
-<body>
-  <header>
-    <h1>Hugo Muller</h1>
-    <p>BTS SIO — option SISR</p>
-    <p class="tagline">Échecs et code : la stratégie au service du développement</p>
-  </header>
+  <body>
+    <header class="site-header">
+      <div class="logo-placeholder" aria-hidden="true"></div>
+      <div class="headings">
+        <h1>Hugo Muller</h1>
+        <p>BTS SIO — option SISR</p>
+      </div>
+      <div class="actions-placeholder" aria-hidden="true"></div>
+    </header>
 
   <main>
     <section class="reveal">
@@ -24,9 +27,9 @@
     </section>
   </main>
 
-  <footer>
-    <small>© <span id="year"></span> Hugo Muller - <a href="https://github.com/Hugo-Mllr" target="_blank" rel="noopener">GitHub</a></small>
-  </footer>
+    <footer>
+      <small>© <span id="year"></span> Hugo Muller - <a href="https://github.com/Hugo-Mllr" target="_blank" rel="noopener">GitHub</a> | <a href="https://www.linkedin.com/in/hugo-muller-6818a332b" target="_blank" rel="noopener">LinkedIn</a></small>
+    </footer>
 
   <script src="script.js"></script>
 </body>

--- a/competences.html
+++ b/competences.html
@@ -10,12 +10,15 @@
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="fond.css">
 </head>
-<body>
-  <header>
-    <h1>Hugo Muller</h1>
-    <p>BTS SIO — option SISR</p>
-    <p class="tagline">Échecs et code : la stratégie au service du développement</p>
-  </header>
+  <body>
+    <header class="site-header">
+      <div class="logo-placeholder" aria-hidden="true"></div>
+      <div class="headings">
+        <h1>Hugo Muller</h1>
+        <p>BTS SIO — option SISR</p>
+      </div>
+      <div class="actions-placeholder" aria-hidden="true"></div>
+    </header>
 
   <main>
     <section class="reveal">
@@ -24,9 +27,9 @@
     </section>
   </main>
 
-  <footer>
-    <small>© <span id="year"></span> Hugo Muller - <a href="https://github.com/Hugo-Mllr" target="_blank" rel="noopener">GitHub</a></small>
-  </footer>
+    <footer>
+      <small>© <span id="year"></span> Hugo Muller - <a href="https://github.com/Hugo-Mllr" target="_blank" rel="noopener">GitHub</a> | <a href="https://www.linkedin.com/in/hugo-muller-6818a332b" target="_blank" rel="noopener">LinkedIn</a></small>
+    </footer>
 
   <script src="script.js"></script>
 </body>

--- a/cv.html
+++ b/cv.html
@@ -10,12 +10,15 @@
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="fond.css">
 </head>
-<body>
-  <header>
-    <h1>Hugo Muller</h1>
-    <p>BTS SIO — option SISR</p>
-    <p class="tagline">Échecs et code : la stratégie au service du développement</p>
-  </header>
+  <body>
+    <header class="site-header">
+      <div class="logo-placeholder" aria-hidden="true"></div>
+      <div class="headings">
+        <h1>Hugo Muller</h1>
+        <p>BTS SIO — option SISR</p>
+      </div>
+      <div class="actions-placeholder" aria-hidden="true"></div>
+    </header>
 
   <main>
     <section class="reveal">
@@ -24,9 +27,9 @@
     </section>
   </main>
 
-  <footer>
-    <small>© <span id="year"></span> Hugo Muller - <a href="https://github.com/Hugo-Mllr" target="_blank" rel="noopener">GitHub</a></small>
-  </footer>
+    <footer>
+      <small>© <span id="year"></span> Hugo Muller - <a href="https://github.com/Hugo-Mllr" target="_blank" rel="noopener">GitHub</a> | <a href="https://www.linkedin.com/in/hugo-muller-6818a332b" target="_blank" rel="noopener">LinkedIn</a></small>
+    </footer>
 
   <script src="script.js"></script>
 </body>

--- a/fond.css
+++ b/fond.css
@@ -17,26 +17,44 @@ body {
     linear-gradient(-45deg, transparent 75%, rgba(0, 0, 0, 0.05) 75%);
   background-size: 40px 40px;
   background-position: 0 0, 0 20px, 20px -20px, -20px 0;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
 }
 
 header,
 main,
 footer {
   background: rgba(255, 255, 255, 0.85);
-  max-width: 900px;
-  margin: 1rem auto;
+  width: 100%;
+  margin: 0;
   padding: 1rem;
-  border-radius: 8px;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
 }
 
+header,
+main {
+  margin-bottom: 1rem;
+}
+
 header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+header .headings {
+  flex: 1;
   text-align: center;
 }
 
-.tagline {
-  color: var(--clr-accent);
-  font-style: italic;
+.logo-placeholder,
+.actions-placeholder {
+  flex: 0 0 50px;
+}
+
+main {
+  flex: 1;
 }
 
 .cards {

--- a/index.html
+++ b/index.html
@@ -11,42 +11,50 @@
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="fond.css">
 </head>
-<body>
-  <header>
-    <h1>Hugo Muller</h1>
-    <p>BTS SIO — option SISR</p>
-    <p class="tagline">Échecs et code : la stratégie au service du développement</p>
-  </header>
-
-  <main>
-    <nav class="menu reveal" aria-label="Menu principal">
-      <h2>Menu</h2>
-      <div class="cards">
-        <a href="cv.html" class="card">
-          <span class="icon">♔</span>
-          <h3>CV</h3>
-        </a>
-        <a href="competences.html" class="card">
-          <span class="icon">♖</span>
-          <h3>Compétences</h3>
-        </a>
-        <a href="certifications.html" class="card">
-          <span class="icon">♗</span>
-          <h3>Certifications</h3>
-        </a>
+  <body>
+    <header class="site-header">
+      <div class="logo-placeholder" aria-hidden="true"></div>
+      <div class="headings">
+        <h1>Hugo Muller</h1>
+        <p>BTS SIO — option SISR</p>
       </div>
-    </nav>
+      <div class="actions-placeholder" aria-hidden="true"></div>
+    </header>
 
-    <section id="a-propos" class="reveal">
-      <h2>À propos</h2>
-      <p>Bienvenue ! Je suis Hugo Muller, étudiant en BTS SIO (option SISR). Ce portfolio regroupe mes travaux pratiques, mes projets personnels et mes expériences professionnelles. L'objectif est de montrer ma progression technique et ma manière de travailler.</p>
-    </section>
-  </main>
+    <main>
+      <nav class="reveal" aria-label="Présentation du BTS SIO">
+        <h2>BTS SIO</h2>
+        <p>Présentation du BTS Services Informatiques aux Organisations. Contenu en construction.</p>
+      </nav>
 
-  <footer>
-    <small>© <span id="year"></span> Hugo Muller - <a href="https://github.com/Hugo-Mllr" target="_blank" rel="noopener">GitHub</a></small>
-  </footer>
+      <nav class="reveal" aria-label="Présentation personnelle">
+        <h2>Présentation personnelle</h2>
+        <p>Bienvenue ! Je suis Hugo Muller, étudiant en BTS SIO (option SISR). Ce portfolio regroupe mes travaux pratiques, mes projets personnels et mes expériences professionnelles. L'objectif est de montrer ma progression technique et ma manière de travailler.</p>
+      </nav>
 
-  <script src="script.js"></script>
-</body>
+      <nav class="menu reveal" aria-label="Menu principal">
+        <h2>Menu</h2>
+        <div class="cards">
+          <a href="cv.html" class="card">
+            <span class="icon">♔</span>
+            <h3>CV</h3>
+          </a>
+          <a href="competences.html" class="card">
+            <span class="icon">♖</span>
+            <h3>Compétences</h3>
+          </a>
+          <a href="certifications.html" class="card">
+            <span class="icon">♗</span>
+            <h3>Certifications</h3>
+          </a>
+        </div>
+      </nav>
+    </main>
+
+    <footer>
+      <small>© <span id="year"></span> Hugo Muller - <a href="https://github.com/Hugo-Mllr" target="_blank" rel="noopener">GitHub</a> | <a href="https://www.linkedin.com/in/hugo-muller-6818a332b" target="_blank" rel="noopener">LinkedIn</a></small>
+    </footer>
+
+    <script src="script.js"></script>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- Remove tagline and expand header for full-width layout with placeholders for logo and future actions
- Add introductory navigation sections for BTS SIO and personal presentation before the main menu
- Link GitHub and LinkedIn in footer and ensure footer stays at bottom

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a49b054f4c8328a2ecebb491c36a35