### PR TITLE
Ajuste la largeur du contenu principal

### DIFF
--- a/fond.css
+++ b/fond.css
@@ -23,7 +23,6 @@ body {
 }
 
 header,
-main,
 footer {
   background: rgba(255, 255, 255, 0.85);
   width: 100%;
@@ -32,8 +31,7 @@ footer {
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
 }
 
-header,
-main {
+header {
   margin-bottom: 1rem;
 }
 
@@ -54,6 +52,12 @@ header .headings {
 }
 
 main {
+  width: 90%;
+  max-width: 1200px;
+  margin: 0 auto 1rem;
+  background: rgba(255, 255, 255, 0.85);
+  padding: 1rem;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
   flex: 1;
 }
 


### PR DESCRIPTION
## Résumé
- Retire `main` de la règle commune afin de conserver l'entête et le pied de page en pleine largeur
- Ajoute une règle `main` dédiée avec largeur centrée, marges et flexbox
- Simplifie les marges en séparant `header` et `main`

## Tests
- `npm test` *(échoue : Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a09d18908328b60906afe5bca01b